### PR TITLE
Feat/release note api - Create Release Note, Get All Release Note API 연결

### DIFF
--- a/src/views/create-release-note/FormReleaseContent.tsx
+++ b/src/views/create-release-note/FormReleaseContent.tsx
@@ -6,13 +6,19 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 
 import CategoryTag, { CategoryType } from 'src/views/create-release-note/CategoryTag';
+import { IconButton } from '@mui/material';
+
+
+import Delete from 'mdi-material-ui/Delete'
 
 export interface FormReleaseContentProps {
   index: number;
   methods: UseFormReturn<any>;
+  field: any;
+  removeContent: () => void;
 }
 
-const FormReleaseContent: React.FC<FormReleaseContentProps> = ({ index, methods}) => {
+const FormReleaseContent: React.FC<FormReleaseContentProps> = ({ index, methods, field, removeContent}) => {
   const { register, setValue, watch } = methods;
   const [selectedCategory, setSelectedCategory] = useState<CategoryType>('General');
 
@@ -41,10 +47,8 @@ const FormReleaseContent: React.FC<FormReleaseContentProps> = ({ index, methods}
   const handleTextFieldChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
 
-    // Update category
     setSelectedCategory('General');
 
-    // Update form state
     setValue(`releaseContent.${index}.releaseSummary`, value, { shouldValidate: true });
   };
 
@@ -58,7 +62,7 @@ const FormReleaseContent: React.FC<FormReleaseContentProps> = ({ index, methods}
           label={`변경사항 ${index + 1}`}
           placeholder="변경사항을 작성해주세요..."
           sx={{ '& .MuiOutlinedInput-root': { alignItems: 'baseline' } }}
-          {...register(`releaseContent.${index}.releaseSummary`)}
+          {...register(`releaseContents.${index}.releaseSummary`)}
           onChange={handleTextFieldChange}
           InputProps={{
             startAdornment: (
@@ -74,11 +78,16 @@ const FormReleaseContent: React.FC<FormReleaseContentProps> = ({ index, methods}
       <Grid container item xs={12} spacing={1}>
         <Grid item xs={12} sm={6}>
           <TextField
-            {...register(`releaseContent.${index}.documentLink`)}
+            {...register(`releaseContents.${index}.documentLink`)}
             fullWidth
             placeholder="연관된 기술문서 링크를 입력해주세요"
           />
         </Grid>
+        <Grid item xs={12} sm={6}>
+          <IconButton onClick={removeContent} aria-label='삭제'>
+            <Delete />
+          </IconButton>
+          </Grid>
       </Grid>
     </Grid>
   );

--- a/src/views/create-release-note/FormReleaseNote.tsx
+++ b/src/views/create-release-note/FormReleaseNote.tsx
@@ -121,7 +121,7 @@ const FormReleaseNote = () => {
       alert('적어도 하나의 릴리즈 콘텐츠가 필요합니다!');
       return;
     }
-    
+
     try {
 
       const creatorId = await getMemberId({ projectId: projectId as string, email: sessionStorage.getItem('email') as string });
@@ -157,7 +157,7 @@ const FormReleaseNote = () => {
 
       console.log(`릴리즈 노트 생성 완료. ID: ${releaseNoteId}`);
 
-      router.push(`/projects/${projectId}/release_notes`);
+      window.history.back();
     } catch (error) {
       // 에러가 발생하면 콘솔에 에러 출력
       console.error('릴리즈 노트 생성 중 문제가 발생했습니다: ', error);

--- a/src/views/create-release-note/FormReleaseNote.tsx
+++ b/src/views/create-release-note/FormReleaseNote.tsx
@@ -159,7 +159,6 @@ const FormReleaseNote = () => {
 
       window.history.back();
     } catch (error) {
-      // 에러가 발생하면 콘솔에 에러 출력
       console.error('릴리즈 노트 생성 중 문제가 발생했습니다: ', error);
     }
   };

--- a/src/views/create-release-note/FormReleaseNote.tsx
+++ b/src/views/create-release-note/FormReleaseNote.tsx
@@ -117,6 +117,11 @@ const FormReleaseNote = () => {
   }
 
   const onSubmit = async (data: ReleaseNoteDataTypes) => {
+    if (data.releaseContents.length === 0) {
+      alert('적어도 하나의 릴리즈 콘텐츠가 필요합니다!');
+      return;
+    }
+    
     try {
 
       const creatorId = await getMemberId({ projectId: projectId as string, email: sessionStorage.getItem('email') as string });
@@ -151,6 +156,8 @@ const FormReleaseNote = () => {
       const { result: releaseNoteId } = response.data;
 
       console.log(`릴리즈 노트 생성 완료. ID: ${releaseNoteId}`);
+
+      router.push(`/projects/${projectId}/release_notes`);
     } catch (error) {
       // 에러가 발생하면 콘솔에 에러 출력
       console.error('릴리즈 노트 생성 중 문제가 발생했습니다: ', error);
@@ -166,7 +173,9 @@ const FormReleaseNote = () => {
             <TextField
               id="release_note_title"
               label="릴리즈 노트 제목"
-              {...register('releaseNoteTitle')}
+              {...register('releaseNoteTitle', {
+                required: '제목을 입력해주세요.',
+              })}
               onChange={handleTitleChange}
               variant="outlined"
               fullWidth
@@ -238,34 +247,42 @@ const FormReleaseNote = () => {
             </Grid>
             <Grid item xs={12}>
               <Controller
-                control={control}
-                name='releaseNoteVersion'
-                rules={{ pattern: versionPattern }}
-                render={({ field }) => {
-                  const hasError = !field.value.match(versionPattern);
-                  return (
-                    <TextField
-                      type='version'
-                      label='버전'
-                      placeholder='x.y.z'
-                      helperText={
-                        hasError
-                          ? '올바른 버전 형식이 아닙니다. x.y.z 형식으로 입력해주세요.'
-                          : 'Major 업데이트의 경우 x를, Minor 업데이트의 경우 y를, Patch 업데이트의 경우 z를 바꿔주세요.'
-                      }
-                      error={hasError} // 버전 입력이 올바르지 않으면 에러 표시
-                      InputProps={{
-                        startAdornment: (
-                          <InputAdornment position='start'>
-                            <Update />
-                          </InputAdornment>
-                        ),
-                      }}
-                      {...field}
-                    />
-                  );
-                }}
-              />
+  control={control}
+  name='releaseNoteVersion'
+  rules={{ 
+    pattern: versionPattern,
+    required: '버전은 필수 항목입니다.' // 이 부분을 추가하세요.
+  }}
+  render={({ field }) => {
+    // 버전 에러 메시지를 추가
+    const errorMsg = (() => {
+      if (!field.value) return '버전은 필수 항목입니다.';
+      if (!field.value.match(versionPattern)) return '올바른 버전 형식이 아닙니다. x.y.z 형식으로 입력해주세요.';
+      return '';
+    })();
+
+    return (
+      <TextField
+        type='version'
+        label='버전'
+        placeholder='x.y.z'
+        helperText={
+          errorMsg
+        }
+        error={!!errorMsg} // 버전 입력이 올바르지 않거나 비어있으면 에러 표시
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position='start'>
+              <Update />
+            </InputAdornment>
+          ),
+        }}
+        {...field}
+      />
+    );
+  }}
+/>
+
             </Grid>
             <Grid item xs={12}>
               <Grid container>

--- a/src/views/create-release-note/FormReleaseNote.tsx
+++ b/src/views/create-release-note/FormReleaseNote.tsx
@@ -2,6 +2,12 @@
 import { useState, useEffect } from 'react';
 import { useForm, Controller, useFieldArray } from 'react-hook-form';
 
+// ** Next Imports
+import { useRouter } from 'next/router';
+
+// ** HTTP Clients
+import axios from 'axios';
+
 // ** MUI Imports
 import Card from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
@@ -25,32 +31,59 @@ import AccountOutline from 'mdi-material-ui/AccountOutline';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { releaseNoteState } from 'src/recoil/release-note/atoms';
 import FormReleaseContent from './FormReleaseContent';
+import { CategoryType } from './CategoryTag';
+import { Category } from './CategoryTag';
+
+interface GetMemberIdParams {
+  projectId: string;
+  email: string;
+}
+
+interface ReleaseNoteDataTypes {
+  creationDate: Date;
+  creatorName: string;
+  releaseNoteTitle: string;
+  releaseNoteVersion: string;
+  releaseNoteIsImportant: boolean;
+  releaseNoteIsPublic: boolean;
+  releaseContents: Array<{
+    releaseSummary: string;
+    category: CategoryType;
+    documentLink: string;
+  }>;
+}
 
 const FormReleaseNote = () => {
-  
+
   const [releaseNote, setReleaseNote] = useRecoilState(releaseNoteState);
   const [releaseContents, setReleaseContents] = useState<string[]>(['']);
 
   const versionPattern = /^(\d+\.){2}\d+$/;
 
-  const methods = useForm(
+  const methods = useForm<ReleaseNoteDataTypes>(
     {
       defaultValues: {
-        creationDate: releaseNote.creationDate,
-        creatorName: typeof window !== 'undefined' ? sessionStorage.getItem('userName') : null,
+        creationDate: new Date(releaseNote.creationDate),
+        creatorName: typeof window !== 'undefined' ? sessionStorage.getItem('userName') ?? undefined : undefined,
         releaseNoteTitle: releaseNote.releaseNoteTitle,
         releaseNoteVersion: releaseNote.version,
         releaseNoteIsImportant: releaseNote.isImportant,
         releaseNoteIsPublic: releaseNote.isPublic,
+        releaseContents: [],
       },
     },
   );
   const { register, control, handleSubmit, setValue } = methods;
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'releaseContents',
+  });
 
 
   const handleReleaseContents = () => {
-    setReleaseContents([...releaseContents, '']);
+    append({ releaseSummary: '', category: Category.General, documentLink: '' });
   };
+
 
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const title = event.target.value;
@@ -60,13 +93,74 @@ const FormReleaseNote = () => {
     });
   };
 
+  const router = useRouter();
+
+  const projectId = router.query.projectId;
+
+  async function getMemberId(params: GetMemberIdParams):Promise<string> {
+    const { projectId, email } = params;
+    const response = await axios
+      .get(`/api/projects/${projectId}/members/info`, {
+        headers: {
+          'Authorization': `Bearer ${sessionStorage.getItem('accessToken')}`,
+        },
+        params: {
+          email: email,
+        }
+      }
+      );
+    const { result: memberId } = response.data;
+
+    return memberId;
+
+
+  }
+
+  const onSubmit = async (data: ReleaseNoteDataTypes) => {
+    try {
+
+      const creatorId = await getMemberId({ projectId: projectId as string, email: sessionStorage.getItem('email') as string });
+      
+      const requestData = {
+        creator: {
+          creatorId: creatorId,
+          creatorName: data.creatorName,
+        },
+        releaseTitle: data.releaseNoteTitle,
+        creationDate: data.creationDate,
+        version: data.releaseNoteVersion,
+        important: data.releaseNoteIsImportant,
+        public: data.releaseNoteIsPublic,
+        releaseContents: data.releaseContents,
+      }
+
+      console.log(requestData);
+      
+      const response = await axios
+      .post(`/api/projects/${projectId}/release_notes`, 
+
+        requestData
+      ,
+      {
+        headers: {
+          'Authorization': `Bearer ${sessionStorage.getItem('accessToken')}`,
+        },
+      }
+      );
+
+      const { result: releaseNoteId } = response.data;
+
+      console.log(`릴리즈 노트 생성 완료. ID: ${releaseNoteId}`);
+    } catch (error) {
+      // 에러가 발생하면 콘솔에 에러 출력
+      console.error('릴리즈 노트 생성 중 문제가 발생했습니다: ', error);
+    }
+  };
+
+
   return (
     <Card>
-      <form onSubmit={
-        handleSubmit((data) => {
-          console.log(data);
-        })
-      }>
+      <form onSubmit={handleSubmit(onSubmit)}>
         <CardHeader
           title={
             <TextField
@@ -87,7 +181,7 @@ const FormReleaseNote = () => {
               <Button
                 variant="outlined"
                 type='submit'
-                onClick={() => {}}
+                onClick={() => { }}
                 color="primary"
                 sx={{ mr: 1, ml: 5 }}
               >
@@ -96,7 +190,7 @@ const FormReleaseNote = () => {
               <Button
                 data-testid="delete-button"
                 variant="outlined"
-                onClick={() => {}}
+                onClick={() => { }}
                 color="error"
               >
                 삭제
@@ -146,7 +240,7 @@ const FormReleaseNote = () => {
               <Controller
                 control={control}
                 name='releaseNoteVersion'
-                rules={{ pattern: versionPattern }} // 버전 유효성 검사 추가
+                rules={{ pattern: versionPattern }}
                 render={({ field }) => {
                   const hasError = !field.value.match(versionPattern);
                   return (
@@ -216,9 +310,10 @@ const FormReleaseNote = () => {
               </Grid>
             </Grid>
 
-            {releaseContents.map((value, index) => (
-              <FormReleaseContent key={index} index={index} methods={methods}/>
+            {fields.map((field, index) => (
+              <FormReleaseContent key={field.id} index={index} methods={methods} field={field} removeContent={() => remove(index)} />
             ))}
+
 
             <Grid item xs={12}>
               <Button

--- a/src/views/project-detail/CategoryTag.tsx
+++ b/src/views/project-detail/CategoryTag.tsx
@@ -1,57 +1,64 @@
-// ** MUI Imports
-import React from "react"
-import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
+import React from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 
 export const Category = {
-    Feature: 'Feature',
-    Changed: 'Changed',
-    Deprecated: 'Deprecated',
-    Fixed: 'Fixed'
-  } as const;
-  export type Category = typeof Category[keyof typeof Category]
-  
-  const categoryColors = {
-    [Category.Feature]: '#C7E3FE',
-    [Category.Changed]: '#FFF8B6',
-    [Category.Deprecated]: '#FFC7C7',
-    [Category.Fixed]: '#BBFFF3',
-  }
-  
-  const categoryTextColors = {
-    [Category.Feature]: '#41A3FF',
-    [Category.Changed]: '#ECD200',
-    [Category.Deprecated]: '#FF5454',
-    [Category.Fixed]: '#05D7B1',
-  }
-  
-  interface CategoryTagProps {
-    category: Category;
-  }
+  General: "General",
+  Feature: "Feature",
+  Changed: "Changed",
+  Deprecated: "Deprecated",
+  Fixed: "Fixed",
+} as const;
+export type CategoryType = typeof Category[keyof typeof Category];
 
-  const CategoryTag: React.FC<CategoryTagProps> = ({ category }) => {
-    return (
-      <Box
+const categoryColors: Record<CategoryType, string> = {
+  [Category.General]: "#CECECE",
+  [Category.Feature]: "#C7E3FE",
+  [Category.Changed]: "#FFF8B6",
+  [Category.Deprecated]: "#FFC7C7",
+  [Category.Fixed]: "#BBFFF3",
+};
+
+const categoryTextColors: Record<CategoryType, string> = {
+  [Category.General]: "#797979",
+  [Category.Feature]: "#41A3FF",
+  [Category.Changed]: "#ECD200",
+  [Category.Deprecated]: "#FF5454",
+  [Category.Fixed]: "#05D7B1",
+};
+
+interface CategoryTagProps {
+  category: CategoryType | string;
+}
+
+const CategoryTag: React.FC<CategoryTagProps> = ({ category }) => {
+  const defaultBackgroundColor = categoryColors[Category.Feature];
+  const defaultTextColor = categoryTextColors[Category.Feature];
+
+  return (
+    <Box
+      sx={{
+        borderRadius: 1,
+        paddingTop: 0.1,
+        paddingBottom: 0.1,
+        paddingLeft: 1,
+        paddingRight: 1,
+        background: categoryColors[category as CategoryType] || defaultBackgroundColor,
+        display: "inline-block",
+        marginRight: 1,
+      }}
+    >
+      <Typography
+        variant="caption"
+        component="span"
         sx={{
-          borderRadius: 1,
-          paddingTop: 0.1,
-          paddingBottom: 0.1,
-          paddingLeft: 1,
-          paddingRight: 1,
-          background: categoryColors[category],
-          display: "inline-block",
-          marginRight: 1,
+          color: categoryTextColors[category as CategoryType] || defaultTextColor,
         }}
       >
-        <Typography
-          variant="caption"
-          component="span"
-          sx={{ color: categoryTextColors[category] }}
-        >
-          <b>{category}</b>
-        </Typography>
-      </Box>
-    );
-  };
-  
-  export default CategoryTag;
+        <b>{category}</b>
+      </Typography>
+    </Box>
+  );
+};
+
+export default CategoryTag;


### PR DESCRIPTION
## PR Checklist
아래 요구사항을 만족하는지 체크:

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)


## PR Type
해당 PR이 포함하는 내용 체크:

- [ ] 패키지
  - [ ] 패키지 추가
  - [ ] 패키지 설정 변경
- [ ] CI
  - [ ] CI 구성 추가
  - [ ] CI 설정 변경
- [ ] 문서화
  - [ ] 신규 문서 추가
  - [ ] 기존 문서 변경
- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 코드 개선
  - [ ] 성능 개선
  - [ ] UI 개선
  - [ ] 성능에 영향을 끼치지 않는 수정
- [ ] 테스트
  - [ ] 테스트 코드 추가
  - [ ] 기존 테스트 코드 변경
- [ ] 커밋 되돌리기
- [ ] 기타

## 스크린샷
<img width="1436" alt="image" src="https://github.com/LogBook-Kkaos/LogBook-FE/assets/84309420/edc81442-40b9-43d8-9e71-6d217b7ab020">
<img width="1436" alt="image" src="https://github.com/LogBook-Kkaos/LogBook-FE/assets/84309420/ee580cc4-750c-4e27-b4f3-ea9db038acf5">



## 추가된 점 또는 변경된 점
- 릴리즈 노트 생성 API 연결
- 릴리즈 콘텐츠 삭제 기능 추가
- 버전 유효성 검사
- 릴리즈 노트 조회 API 연결

## 주의사항 및 참고사항
- 릴리즈 노트 생성 시 카테고리가 General로 들어가는 버그가 있음
- 가능하면 테이블 위쪽에 간단하게 릴리즈 노트를 추가하는 UI/UX로 수정하고 싶음
- 각 릴리즈 노트를 누르면 상세 보기 기능 추가
- 도큐먼트 링크 연결해야함
- 이전 릴리즈 노트 제목이 계속 떠 있음...
